### PR TITLE
feat: Concurrent requests, minor changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .vscode
 /target
 config.json
+config.test.json

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,54 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
+name = "anstream"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ab91ebe16eb252986481c5b62f6098f3b698a45e34b5b98200cf20dd2484a44"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7079075b41f533b8c61d2a4d073c4676e1f8b249ff94a393b0595db304e0dd87"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "317b9a89c1868f5ea6ff1d9539a69f45dffc21ce321ac1fd1160dfa48c8e2140"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca11d4be1bab0c8bc8734a9aa7bf4ee8316d462a08c6ac5052f888fef5b494b"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0699d10d2f4d628a98ee7b57b289abbc98ff3bad977cb3152709d4bf2330628"
+dependencies = [
+ "anstyle",
+ "windows-sys",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -84,6 +132,52 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "clap"
+version = "4.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d04704f56c2cde07f43e8e2c154b43f216dc5c92fc98ada720177362f953b956"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e231faeaca65ebd1ea3c737966bf858971cd38c3849107aa3ea7de90a804e45"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0862016ff20d69b84ef8247369fabf5c008a7417002411897d40ee1f4532b873"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd7cc57abe963c6d3b9d8be5b06ba7c8957a930305ca90304f24ef040aa6f961"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
+
+[[package]]
 name = "core-foundation"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -103,6 +197,7 @@ checksum = "e496a50fda8aacccc86d7529e2c1e0892dbd0f898a6b5645b5561b89c3210efa"
 name = "ddns-rs"
 version = "1.0.0"
 dependencies = [
+ "clap",
  "error-chain",
  "reqwest",
  "serde",
@@ -264,6 +359,12 @@ name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+
+[[package]]
+name = "heck"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "hermit-abi"
@@ -798,6 +899,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "strsim"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
 name = "syn"
 version = "2.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -953,6 +1060,12 @@ dependencies = [
  "idna",
  "percent-encoding",
 ]
+
+[[package]]
+name = "utf8parse"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 
 [[package]]
 name = "vcpkg"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -195,7 +195,7 @@ checksum = "e496a50fda8aacccc86d7529e2c1e0892dbd0f898a6b5645b5561b89c3210efa"
 
 [[package]]
 name = "ddns-rs"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "clap",
  "error-chain",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,3 +11,4 @@ error-chain = "0.12.4"
 serde_json = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 tokio = { version = "1", features = ["full"] }
+clap = { version = "4.4.6", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ddns-rs"
-version = "1.0.0"
+version = "1.1.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/src/command.rs
+++ b/src/command.rs
@@ -1,0 +1,9 @@
+use clap::Parser;
+
+#[derive(Parser, Debug)]
+#[command(author, version, about, long_about = None)]
+pub struct Args {
+    /// Name of the person to greet
+    #[arg(short, long, default_value="config.json")]
+    pub config: String,
+}

--- a/src/command.rs
+++ b/src/command.rs
@@ -4,6 +4,6 @@ use clap::Parser;
 #[command(author, version, about, long_about = None)]
 pub struct Args {
     /// Name of the person to greet
-    #[arg(short, long, default_value="config.json")]
+    #[arg(short, long, default_value = "config.json")]
     pub config: String,
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,5 +1,5 @@
+use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
-use serde::{Serialize, Deserialize};
 use std::{error::Error, fs::File};
 
 #[derive(Debug, Serialize, Deserialize, Clone)]

--- a/src/ip.rs
+++ b/src/ip.rs
@@ -6,9 +6,10 @@ struct IP {
     origin: String
 }
 
-pub fn get_public_ip() -> Result<String, Box<dyn Error>> {
-    let resp: IP = reqwest::blocking::get("https://httpbin.org/ip")?
-        .json()?;
+pub async fn get_public_ip() -> Result<String, Box<dyn Error>> {
+    let resp: IP = reqwest::get("https://httpbin.org/ip").await?
+        .json()
+        .await?;
     
     Ok(resp.origin)
 }

--- a/src/ip.rs
+++ b/src/ip.rs
@@ -1,15 +1,13 @@
-use std::error::Error;
 use serde::Deserialize;
+use std::error::Error;
 
 #[derive(Deserialize)]
 struct IP {
-    origin: String
+    origin: String,
 }
 
 pub async fn get_public_ip() -> Result<String, Box<dyn Error>> {
-    let resp: IP = reqwest::get("https://httpbin.org/ip").await?
-        .json()
-        .await?;
-    
+    let resp: IP = reqwest::get("https://httpbin.org/ip").await?.json().await?;
+
     Ok(resp.origin)
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,24 +1,32 @@
 use std::error::Error;
+use clap::Parser;
 
+mod command;
 mod record;
 mod config;
 mod ip;
 
-fn main() -> Result<(), Box<dyn Error>> {
-    let config = config::read_config("./config.json")?;
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn Error>> {
+    let args = command::Args::parse();
+    let config = config::read_config(&args.config)?;
 
-    let public_ip = ip::get_public_ip()?;
+    let public_ip = ip::get_public_ip().await?;
 
     println!("Public IP: {}", public_ip);
 
-    config.clone().records_to_update.into_iter().for_each(|item| {
+    // let mut threads = 
+    let records = config.records_to_update.clone();
+    for item in records {
         let zone_id = item.1.zone_id.clone();
         println!("Getting records for zone {}", &zone_id);
-        match record::get_records_for_zone(&config, &zone_id, &public_ip) {
-            Ok(r) => record::update_records(config.clone(), r, &public_ip),
+        match record::get_records_for_zone(&config, &zone_id, &public_ip).await {
+            Ok(r) => {
+                record::update_records(config.clone(), r, &public_ip).await;
+            },
             Err(e) => eprintln!("error: {}", e),
         };
-    });
+    }
     
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,10 +1,10 @@
-use std::error::Error;
 use clap::Parser;
+use std::error::Error;
 
 mod command;
-mod record;
 mod config;
 mod ip;
+mod record;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn Error>> {
@@ -15,7 +15,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
     println!("Public IP: {}", public_ip);
 
-    // let mut threads = 
+    // let mut threads =
     let records = config.records_to_update.clone();
     for item in records {
         let zone_id = item.1.zone_id.clone();
@@ -23,10 +23,10 @@ async fn main() -> Result<(), Box<dyn Error>> {
         match record::get_records_for_zone(&config, &zone_id, &public_ip).await {
             Ok(r) => {
                 record::update_records(config.clone(), r, &public_ip).await;
-            },
+            }
             Err(e) => eprintln!("error: {}", e),
         };
     }
-    
+
     Ok(())
 }

--- a/src/record.rs
+++ b/src/record.rs
@@ -1,9 +1,9 @@
+use crate::config::Config;
 use reqwest::{
-    header::{HeaderMap, CONTENT_TYPE, AUTHORIZATION},
+    header::{HeaderMap, AUTHORIZATION, CONTENT_TYPE},
     Response,
 };
-use serde::{Serialize, Deserialize};
-use crate::config::Config;
+use serde::{Deserialize, Serialize};
 use std::error::Error;
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -24,8 +24,19 @@ pub struct Record {
 }
 
 impl Record {
+    fn new(id: &str, zone_id: &str, name: &str, kind: &str, content: &str) -> Record {
+        Record {
+            id: String::from(id),
+            zone_id: String::from(zone_id),
+            name: String::from(name),
+            kind: String::from(kind),
+            content: String::from(content),
+        }
+    }
+
     async fn update(self, config: &Config, ip: &str) -> Result<Response, reqwest::Error> {
-        let url = format!("https://api.cloudflare.com/client/v4/zones/{zone_id}/dns_records/{record_id}",
+        let url = format!(
+            "https://api.cloudflare.com/client/v4/zones/{zone_id}/dns_records/{record_id}",
             zone_id = self.zone_id,
             record_id = self.id
         );
@@ -34,24 +45,29 @@ impl Record {
 
         let mut headers: HeaderMap = HeaderMap::new();
         headers.append(CONTENT_TYPE, "application/json".parse().unwrap());
-        headers.append(AUTHORIZATION, format!("Bearer {}", config.cf_api_key).parse().unwrap());
+        headers.append(
+            AUTHORIZATION,
+            format!("Bearer {}", config.cf_api_key).parse().unwrap(),
+        );
 
         let mut patch = self;
         patch.content = ip.to_owned();
 
         let client = reqwest::Client::new();
-        client.put(url)
-            .headers(headers)
-            .json(&patch)
-            .send()
-            .await
+        client.put(url).headers(headers).json(&patch).send().await
     }
 }
 
-pub async fn get_records_for_zone(config: &Config, zone_id: &String, ip: &String) -> Result<Vec<Record>, Box<dyn Error>> {
-    let url = format!("https://api.cloudflare.com/client/v4/zones/{zone_id}/dns_records",
-                               zone_id = zone_id);
-    
+pub async fn get_records_for_zone(
+    config: &Config,
+    zone_id: &String,
+    ip: &String,
+) -> Result<Vec<Record>, Box<dyn Error>> {
+    let url = format!(
+        "https://api.cloudflare.com/client/v4/zones/{zone_id}/dns_records",
+        zone_id = zone_id
+    );
+
     let api_key = config.cf_api_key.clone();
 
     println!("URL: {}", url);
@@ -59,10 +75,14 @@ pub async fn get_records_for_zone(config: &Config, zone_id: &String, ip: &String
 
     let mut headers: HeaderMap = HeaderMap::new();
     headers.append(CONTENT_TYPE, "application/json".parse().unwrap());
-    headers.append(AUTHORIZATION, format!("Bearer {}", api_key).parse().unwrap());
+    headers.append(
+        AUTHORIZATION,
+        format!("Bearer {}", api_key).parse().unwrap(),
+    );
 
     let client = reqwest::Client::new();
-    let resp: CfResponse = client.get(url)
+    let resp: CfResponse = client
+        .get(url)
         .headers(headers)
         .send()
         .await?
@@ -88,19 +108,19 @@ pub async fn update_records(config: Config, records: Vec<Record>, ip: &str) {
             Ok(_) => println!("Successfully updated record {}", record_name),
             Err(e) => eprintln!("Failed to update record {}: {}", record_name, e),
         }
-    };
+    }
 }
 
 fn record_filter(config: &Config, record: &Record, new_ip: &String) -> bool {
     if record.kind != "A" {
-        return false
+        return false;
     }
 
     let zone_config = config.records_to_update.get(&record.zone_id);
     match zone_config {
         None => {
             return false;
-        },
+        }
         Some(zone) => {
             if !zone.records.contains(&record.name) {
                 return false;
@@ -115,4 +135,86 @@ fn record_filter(config: &Config, record: &Record, new_ip: &String) -> bool {
     }
 
     true
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use crate::{
+        config::{Config, ZoneConfig},
+        record::{record_filter, Record},
+    };
+
+    #[test]
+    fn drop_non_a_record() {
+        let record = Record::new("", "", "", "CNAME", "");
+
+        assert_eq!(
+            false,
+            record_filter(&empty_config(), &record, &String::from(""))
+        )
+    }
+
+    #[test]
+    fn drop_unexpected_zone() {
+        let record = Record::new("", "foo", "", "A", "");
+
+        assert_eq!(
+            false,
+            record_filter(&empty_config(), &record, &String::from(""))
+        )
+    }
+
+    #[test]
+    fn drop_unexpected_record() {
+        let zone_id = "foo";
+        let mut config = empty_config();
+        config.records_to_update.insert(
+            String::from(zone_id),
+            ZoneConfig { zone_id: String::from(zone_id), records: vec![] },
+        );
+        let record = Record::new("", zone_id, "", "A", "");
+
+        assert_eq!(
+            false,
+            record_filter(&empty_config(), &record, &String::from(""))
+        )
+    }
+
+    #[test]
+    fn drop_up_to_date_record() {
+        let zone_id = "foo";
+        let record_name = "bar";
+        let ip = "192.168.1.1";
+        let mut config = empty_config();
+        config.records_to_update.insert(
+            String::from(zone_id),
+            ZoneConfig { zone_id: String::from(zone_id), records: vec![
+                String::from(record_name),
+            ] },
+        );
+        let record = Record::new("", zone_id, record_name, "A", ip);
+
+        assert_eq!(
+            false,
+            record_filter(&empty_config(), &record, &String::from(ip))
+        )
+    }
+
+    fn empty_config() -> Config {
+        let mut record = HashMap::new();
+        record.insert(
+            String::from("foo"),
+            ZoneConfig {
+                zone_id: String::from(""),
+                records: vec![],
+            },
+        );
+
+        Config {
+            cf_api_key: String::from(""),
+            records_to_update: record,
+        }
+    }
 }


### PR DESCRIPTION
* Added flag for config file path
* Changed HTTP requests to use the async runtime
* Refactored the `update` function as functionality for the `Record` type
* Added `new()` method for `Record` type to construct form `&str` values (mainly for testing)
* Added tests for the `record_filter` function
* Ran `rustfmt`